### PR TITLE
Define non-standard M_PI if not already defined

### DIFF
--- a/src/Common.h
+++ b/src/Common.h
@@ -224,6 +224,10 @@ constexpr int div_ceil(int numerator, int denominator) {
   return (numerator / denominator) + (((numerator < 0) ^ (denominator > 0)) && (numerator % denominator));
 }
 
+#ifndef M_PI
+#define M_PI 3.14159265358979323846
+#endif
+
 constexpr double rad2deg(const double rad) {
   return rad * (180.0 / M_PI);
 }


### PR DESCRIPTION
Fixes at least cross-compiling on MinGW-w64