### PR TITLE
Implement bare palette map output

### DIFF
--- a/src/Map.cpp
+++ b/src/Map.cpp
@@ -82,6 +82,17 @@ byte_vec_t Map::native_data(bool column_order, unsigned split_w, unsigned split_
   return data;
 }
 
+byte_vec_t Map::palette_map(bool column_order, unsigned split_w, unsigned split_h) const {
+  byte_vec_t data;
+  for (const auto& vm : collect_entries(column_order, split_w, split_h)) {
+    for (const auto& m : vm) {
+      data.push_back(m.palette_index & 0xFF);
+      data.push_back(m.palette_index >> 8);
+    }
+  }
+  return data;
+}
+
 byte_vec_t Map::snes_mode7_interleaved_data(const Tileset& tileset) const {
   auto map_data = native_data();
   auto tile_data = tileset.native_data();
@@ -109,6 +120,10 @@ byte_vec_t Map::gbc_banked_data() const {
 
 void Map::save(const std::string& path, bool column_order, unsigned split_w, unsigned split_h) const {
   sfc::write_file(path, native_data(column_order, split_w, split_h));
+}
+
+void Map::save_pal_map(const std::string& path, bool column_order, unsigned split_w, unsigned split_h) const {
+  sfc::write_file(path, palette_map(column_order, split_w, split_h));
 }
 
 const std::string Map::to_json(bool column_order, unsigned split_w, unsigned split_h) const {

--- a/src/Map.h
+++ b/src/Map.h
@@ -43,10 +43,12 @@ struct Map final {
   void add_palette_base_offset(int offset);
 
   byte_vec_t native_data(bool column_order = false, unsigned split_w = 0, unsigned split_h = 0) const;
+  byte_vec_t palette_map(bool column_order = false, unsigned split_w = 0, unsigned split_h = 0) const;
   byte_vec_t snes_mode7_interleaved_data(const Tileset& tileset) const;
   byte_vec_t gbc_banked_data() const;
 
   void save(const std::string& path, bool column_order = false, unsigned split_w = 0, unsigned split_h = 0) const;
+  void save_pal_map(const std::string& path, bool column_order = false, unsigned split_w = 0, unsigned split_h = 0) const;
   const std::string to_json(bool column_order = false, unsigned split_w = 0, unsigned split_h = 0) const;
 
 private:

--- a/src/sfc_map.cpp
+++ b/src/sfc_map.cpp
@@ -19,6 +19,7 @@ struct Settings {
   std::string out_json;
   std::string out_m7_data;
   std::string out_gbc_bank;
+  std::string out_pal_map;
 
   sfc::Mode mode;
   unsigned bpp;
@@ -55,6 +56,7 @@ int sfc_map(int argc, char* argv[]) {
     options.Add(settings.out_json,            'j', "out-json",            "Output: json");
     options.Add(settings.out_m7_data,         '7', "out-m7-data",         "Output: interleaved map/tile data (snes_mode7)");
     options.Add(settings.out_gbc_bank,       '\0', "out-gbc-bank",        "Output: banked map data (gbc)");
+    options.Add(settings.out_pal_map,        '\0', "out-pal-map",         "Output: palette map (native 16-bit LE)");
 
     options.Add(mode_str,                     'M', "mode",                "Mode <default: snes>",                       std::string("snes"),  "Settings");
     options.Add(settings.bpp,                 'B', "bpp",                 "Bits per pixel",                             unsigned(4),          "Settings");
@@ -161,6 +163,12 @@ int sfc_map(int argc, char* argv[]) {
       map.save(settings.out_data, settings.column_order, settings.map_split_w, settings.map_split_h);
       if (verbose)
         fmt::print("Saved native map data to \"{}\"\n", settings.out_data);
+    }
+
+    if (!settings.out_pal_map.empty()) {
+      map.save_pal_map(settings.out_pal_map, settings.column_order, settings.map_split_w, settings.map_split_h);
+      if (verbose)
+        fmt::print("Saved palette map to \"{}\"\n", settings.out_pal_map);
     }
 
     if (!settings.out_json.empty()) {


### PR DESCRIPTION
Useful when you're planning to dynamically load palettes from a pool larger than what the hardware natively supports.

Intentionally limited to 16-bit LE, as more than 65k palettes seems unrealistic. (Also, the C standard only mandates `int` to be at least 16 bits, so this is more portable! :stuck_out_tongue_winking_eye:)

Note: I couldn't test it at the time of this PR, just submitting it early for review.