### PR TITLE
Add 1bpp and 8x16 for DMG/CGB

### DIFF
--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -219,7 +219,7 @@ std::vector<Image> Image::crops(unsigned tile_width, unsigned tile_height, Mode 
       x += tile_width;
     }
     x = 0;
-    y += tile_width;
+    y += tile_height;
   }
   return v;
 }

--- a/src/Mode.h
+++ b/src/Mode.h
@@ -161,10 +161,10 @@ constexpr bool tile_width_allowed_for_mode(unsigned width, Mode mode) {
 constexpr bool tile_height_allowed_for_mode(unsigned height, Mode mode) {
   switch (mode) {
   case Mode::snes:
-    return height == 8 || height == 16;
-  case Mode::snes_mode7:
   case Mode::gb:
   case Mode::gbc:
+    return height == 8 || height == 16;
+  case Mode::snes_mode7:
   case Mode::gba:
   case Mode::gba_affine:
   case Mode::md:

--- a/src/Mode.h
+++ b/src/Mode.h
@@ -97,7 +97,7 @@ constexpr bool bpp_allowed_for_mode(unsigned bpp, Mode mode) {
     return bpp == 8;
   case Mode::gb:
   case Mode::gbc:
-    return bpp == 2;
+    return bpp == 1 || bpp == 2;
   case Mode::gba:
     return bpp == 4 || bpp == 8;
   case Mode::gba_affine:
@@ -513,7 +513,7 @@ inline byte_vec_t pack_native_tile(const index_vec_t& data, Mode mode, unsigned 
   };
 
   // regular bit planes
-  auto make_1bit_planes = [](const index_vec_t& in_data, unsigned plane) {
+  auto make_1bit_planes = [](const index_vec_t& in_data, unsigned plane, bool reverse) {
     if (in_data.size() % 8)
       throw std::runtime_error("programmer error (in_data not multiple of 8 in make_1bit_planes)");
 
@@ -527,8 +527,12 @@ inline byte_vec_t pack_native_tile(const index_vec_t& data, Mode mode, unsigned 
     for (unsigned index_b = 0, index_i = 0; index_b < plane_size; ++index_b) {
       index_t byte = 0;
       for (unsigned b = 0; b < 8; ++b) {
-        if (in_data[index_i + b] & mask)
-          byte |= 1 << b;
+        if (in_data[index_i + b] & mask) {
+          if (reverse)
+            byte |= 1 << (7-b);
+          else
+            byte |= 1 << b;
+        }
       }
       p[index_b] = byte;
       index_i += 8;
@@ -560,6 +564,11 @@ inline byte_vec_t pack_native_tile(const index_vec_t& data, Mode mode, unsigned 
       auto plane = make_2bit_planes(data, i * 2);
       nd.insert(nd.end(), plane.begin(), plane.end());
     }
+    // 1bpp had 0 iterations
+    if(bpp == 1) {
+      auto plane = make_1bit_planes(data, 0, true);
+      nd.insert(nd.end(), plane.begin(), plane.end());
+    }
 
   } else if (mode == Mode::snes_mode7) {
     nd = data;
@@ -573,7 +582,7 @@ inline byte_vec_t pack_native_tile(const index_vec_t& data, Mode mode, unsigned 
 
   } else if (mode == Mode::pce_sprite) {
     for (unsigned p = 0; p < 4; ++p) {
-      auto plane = make_1bit_planes(data, p);
+      auto plane = make_1bit_planes(data, p, false);
       nd.insert(nd.end(), plane.begin(), plane.end());
     }
   }

--- a/src/Tiles.cpp
+++ b/src/Tiles.cpp
@@ -229,10 +229,11 @@ byte_vec_t Tileset::native_data() const {
 std::vector<Tile> Tileset::remap_tiles_for_output(const std::vector<Tile>& tiles, Mode mode) const {
   std::vector<Tile> tv;
 
-  if (mode == Mode::snes && (_tile_width == 16 || _tile_height == 16)) {
+  if ((mode == Mode::snes && (_tile_width == 16 || _tile_height == 16))
+      || ( (mode == Mode::gb || mode == Mode::gbc) && _tile_height == 16)) {
     const unsigned cells_per_tile_h = _tile_width / 8;
     const unsigned cells_per_tile_v = _tile_height / 8;
-    const unsigned cells_per_row = 16;
+    const unsigned cells_per_row = (mode == Mode::snes ? 16:1);
     const unsigned tiles_per_row = cells_per_row / cells_per_tile_h;
     const unsigned cell_rows = div_ceil((int)tiles.size(), tiles_per_row) * cells_per_tile_v;
     tv.resize(cells_per_row * cell_rows);
@@ -257,7 +258,8 @@ std::vector<Tile> Tileset::remap_tiles_for_output(const std::vector<Tile>& tiles
 std::vector<Tile> Tileset::remap_tiles_for_input(const std::vector<Tile>& tiles, Mode mode) const {
   std::vector<Tile> tv;
 
-  if (mode == Mode::snes && (_tile_width == 16 || _tile_height == 16)) {
+  if ((mode == Mode::snes && (_tile_width == 16 || _tile_height == 16))
+      || ( (mode == Mode::gb || mode == Mode::gbc) && _tile_height == 16)) {
     const unsigned cells_per_tile_h = _tile_width / 8;
     const unsigned cells_per_tile_v = _tile_height / 8;
 
@@ -265,8 +267,8 @@ std::vector<Tile> Tileset::remap_tiles_for_input(const std::vector<Tile>& tiles,
       std::vector<Tile> metatile;
       for (unsigned yo = 0; yo < cells_per_tile_v; ++yo) {
         for (unsigned xo = 0; xo < cells_per_tile_h; ++xo) {
-          if ((i + (yo * 16) + xo) < tiles.size())
-            metatile.push_back(tiles[i + (yo * 16) + xo]);
+          if ((i + (yo * (mode == Mode::snes ? 16:1)) + xo) < tiles.size())
+            metatile.push_back(tiles[i + (yo * (mode == Mode::snes ? 16:1)) + xo]);
         }
       }
       if (metatile.size() == cells_per_tile_h * cells_per_tile_v)

--- a/src/Tiles.cpp
+++ b/src/Tiles.cpp
@@ -243,7 +243,7 @@ std::vector<Tile> Tileset::remap_tiles_for_output(const std::vector<Tile>& tiles
       const auto ct = tiles[i].crops(8, 8);
       for (unsigned cy = 0; cy < cells_per_tile_v; ++cy) {
         for (unsigned cx = 0; cx < cells_per_tile_h; ++cx) {
-          tv[base_pos + (cy * cells_per_row) + cx] = ct[(cy * cells_per_tile_v) + cx];
+          tv[base_pos + (cy * cells_per_row) + cx] = ct[(cy * cells_per_tile_h) + cx];
         }
       }
     }
@@ -251,7 +251,6 @@ std::vector<Tile> Tileset::remap_tiles_for_output(const std::vector<Tile>& tiles
   } else {
     throw std::runtime_error("programmer error (remap_tiles_for_output invoked erroneously invoked)");
   }
-
   return tv;
 }
 


### PR DESCRIPTION
This implements 1bpp (half 2bpp) and 8x16 (used in sprites) for original Game Boy and Game Boy Color.

Implements #25 

1bpp is not supported by the hardware, but easily realized with software, it's just
```asm
ld a, (hl+)
ld (de), a
ld (de), a
inc de
```

Tested with
```sh
#!/bin/sh
sfc=../bin/superfamiconv
testfile=cgb_dmg_testpattern.png
echo === 1bpp
${sfc} tiles -v -Mgb --no-remap -B 1 -i ${testfile} -d ${testfile}.1bpp -o ${testfile}.1bpp.png
echo === 1bpp
${sfc} tiles -v -Mgb --no-remap -B 1 -i cgb_dmg_testpattern_mono.png -d ${testfile}_mono.1bpp -o ${testfile}_mono.1bpp.png
echo === 2bpp
${sfc} tiles -v -Mgb --no-remap -i ${testfile} -d ${testfile}.2bpp -o ${testfile}.2bpp.png
echo === sprite
${sfc} tiles -v -Mgb --no-remap --sprite-mode -i ${testfile} -d ${testfile}.spr.2bpp -o ${testfile}.spr.2bpp.png
echo === 8x16
${sfc} tiles -v -Mgb --no-remap -H 16 -i ${testfile} -d ${testfile}.16.2bpp -o ${testfile}.16.2bpp.png
```
and


![cgb_dmg_testpattern](https://user-images.githubusercontent.com/1314450/114929117-af823980-9e33-11eb-9ce7-72803df77a18.png)
![cgb_dmg_testpattern_mono](https://user-images.githubusercontent.com/1314450/114929135-b27d2a00-9e33-11eb-8f71-3a27665fdfe4.png)

