### PR TITLE
Fix remap_tiles_for_output() for -W16

### DIFF
--- a/src/Tiles.cpp
+++ b/src/Tiles.cpp
@@ -240,7 +240,7 @@ std::vector<Tile> Tileset::remap_tiles_for_output(const std::vector<Tile>& tiles
 
     for (unsigned i = 0; i < tiles.size(); ++i) {
       unsigned base_pos =
-        (((i / tiles_per_row) * cells_per_tile_v) * cells_per_row) + ((i % tiles_per_row) << (cells_per_tile_h - 2));
+        (((i / tiles_per_row) * cells_per_tile_v) * cells_per_row) + ((i % tiles_per_row) * cells_per_tile_h);
       const auto ct = tiles[i].crops(8, 8);
       for (unsigned cy = 0; cy < cells_per_tile_v; ++cy) {
         for (unsigned cx = 0; cx < cells_per_tile_h; ++cx) {


### PR DESCRIPTION
This PR fixes a bug when converting SNES tiles with the `-W16` argument.

It also fixes a segfault when converting tiles with `-W8 -H16` arguments.

EDIT: This PR has **not been tested** with non SNES tiles and it has **not been tested** with a tile size > 16 pixels.

---

Source image:
![test](https://github.com/user-attachments/assets/e2073124-a5a4-4cd9-904b-0f82303c8081)

```
superfamiconv -B 4 -S -D -F -W 16 -H 16 -i test.png -t out/test.4bpp -p out/test.pal
```

Before (v0.11.0):
![v0-11-0-output](https://github.com/user-attachments/assets/1e0bc79a-126c-4b8e-bc35-e70b3729edd6)

After:
![fixed-output](https://github.com/user-attachments/assets/9560d24d-8400-4544-801c-6bfb60c9fff5)

